### PR TITLE
fix(order-form): submit value change

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project represents a challenge to test your git flow, programming, and trou
 ## Challenge Instructions
 You will begin by creating a fork of this repository to your own Github account. All work will be completed and reviewed within your own fork. Please do not create a Pull Request (PR) back into this repository.
 
-Once you have created your fork, review the Issues labeled `challenge task` [HERE](https://github.com/Shift3/react-challenge-project-2/issues?q=is%3Aissue+is%3Aopen+label%3A%22challenge+task%22). Shift3's standard for branching is as follows:
+Once you have created your fork, review the Issues labeled `challenge task` [HERE](https://github.com/Shift3/react-challenge-project-jan-2022/issues?q=is%3Aissue+is%3Aopen+label%3A%22challenge+task%22). Shift3's standard for branching is as follows:
 
 - Maintain a `main` and development (`dev`) branch on your fork
 - For each feature/task (Issue), create a new branch based off of your `dev` branch

--- a/application/src/components/order-form/order-form.js
+++ b/application/src/components/order-form/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 
@@ -38,8 +38,8 @@ export default function OrderForm(props) {
             <div className="form-wrapper">
                 <form>
                     <label className="form-label">I'd like to order...</label><br />
-                    <select 
-                        value={orderItem} 
+                    <select
+                        value={orderItem}
                         onChange={(event) => menuItemChosen(event)}
                         className="menu-select"
                     >


### PR DESCRIPTION
## Changes
1. Changes the scope of the `menuItemChosen` function's event argument to include the DOM objects `target` object before specifying its value.

## Purpose
After a user selects a menu item, they need to be able to submit that order successfully to be stored in the database with the correct item value. 

Proposed solution for [Intentional Bug: Order form submit doesn't work #1](https://github.com/Shift3/react-challenge-project-jan-2022/issues/1)

## Approach
- First, I tested the bug as a user to check that I'm able to reproduce the bug.  
- Then proceeded to investigate any error messages within the browser's console, or running cli environments. 
- With the console's error messages I was able to determine the react component and html element that was responsible for the bug. 

## Pre-Testing TODOs
- Run local environments 
  - Docker backend: `docker compose up`
  - Browser client: `npm start`
- Visit `localhost:3000` in your browser and login (NOTE: any email & password will be accepted)

## Testing Steps
- Select "Order Form" button in the navbar. 
- Select an Item from the "Lunch menu" dropdown, then the "Order It" Button
- Select "View Order" and see your newly selected Item displayed. 
