### PR TITLE
test(order-list): verify time format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/application/package.json
+++ b/application/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "TZ=UTC react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -8,6 +8,15 @@ const OrdersList = (props) => {
         </div>
     );
 
+    const formatDate = (hour, minute, second) => {
+        const hh = format24Hour(hour);
+        const mm = zeroPadDigit(minute);
+        const ss = zeroPadDigit(second);
+        return hh + ":" + mm + ":" + ss;
+    }
+    const zeroPadDigit = (n) => n > 9 ? n : `0${n}`;
+    const format24Hour = (n) => n > 12 ? zeroPadDigit(n - 12) : zeroPadDigit(n);
+
     return orders.map(order => {
         const createdDate = new Date(order.createdAt);
         return (
@@ -17,7 +26,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {formatDate(createdDate.getHours(),createdDate.getMinutes(),createdDate.getSeconds())}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">

--- a/application/src/components/view-orders/ordersList.test.js
+++ b/application/src/components/view-orders/ordersList.test.js
@@ -55,4 +55,19 @@ describe('Orders List', () => {
         expect(screen.getByText(/^.*888.*$/gm)).toBeInTheDocument();
 
     });
+
+    test('verify time formating', () => {
+        const orders = [
+            {
+                createdAt: "2022-04-17T21:09:05.048Z",
+                _id: 1
+            }
+        ];
+        render(
+            <OrdersList
+                orders={orders}
+            />
+        )
+        expect(screen.getByText(/09:09:05/)).toBeInTheDocument();
+  });
 })

--- a/application/src/components/view-orders/ordersList.test.js
+++ b/application/src/components/view-orders/ordersList.test.js
@@ -56,7 +56,7 @@ describe('Orders List', () => {
 
     });
 
-    test('verify time formating', () => {
+    test('verify time formatting', () => {
         const orders = [
             {
                 createdAt: "2022-04-17T21:09:05.048Z",


### PR DESCRIPTION
## Changes
1. Adds test `verify time formatting` to `orderList.test.js`.
2. Updates `npm test` command in `package.json` to force UTC time for universal testing.

## Purpose
This test is added to check that the `order-list.js` component is formatting test times correctly as HH:MM:SS.
- Forcing tests to always use UTC is needed so that false errors will not be created when testing outside of specific timezones. 

Proposed solution for [Feature Request: Test for correct time display #3](https://github.com/Shift3/react-challenge-project-jan-2022/issues/3)
- Includes proposed solution for [Bug: Order Time does not format time correctly #2](https://github.com/Shift3/react-challenge-project-jan-2022/issues/2)

## Approach
This test is run by giving the `order-list.js` component specific times and then checking to see if the DOM includes the times rendered as expected. 

## Testing Steps
- Run in `npm test` to view results.

## Learning
- Discussion on timezone tests: https://github.com/jest-community/vscode-jest/issues/153
  - Comment I used: https://github.com/jest-community/vscode-jest/issues/153#issuecomment-508843885