### PR TITLE
fix(auth-reducer): payload value change

### DIFF
--- a/application/src/components/order-form/order-form.js
+++ b/application/src/components/order-form/order-form.js
@@ -10,7 +10,7 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
     const menuQuantityChosen = (event) => setQuantity(event.value);
 
     const auth = useSelector((state) => state.auth);
@@ -38,8 +38,8 @@ export default function OrderForm(props) {
             <div className="form-wrapper">
                 <form>
                     <label className="form-label">I'd like to order...</label><br />
-                    <select 
-                        value={orderItem} 
+                    <select
+                        value={orderItem}
                         onChange={(event) => menuItemChosen(event)}
                         className="menu-select"
                     >

--- a/application/src/components/order-form/order-form.js
+++ b/application/src/components/order-form/order-form.js
@@ -11,7 +11,7 @@ export default function OrderForm(props) {
     const [quantity, setQuantity] = useState("1");
 
     const menuItemChosen = (event) => setOrderItem(event.target.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuQuantityChosen = (event) => setQuantity(event.targe.value);
 
     const auth = useSelector((state) => state.auth);
 

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
## Changes
1. Changes the `payload` value from `login` to `email` so that the correct user email is stored with the order item.

## Purpose
When a user selects a menu item, their email needs to be saved for reference to be displayed on the "Order View" page. 

## Approach
- First, I tested the bug as a user to check that I'm able to reproduce the bug.  
- I was able to track back through the code and files to find where the value of the user was being mislabeled as `login` rather than `email`.

Proposed solution for [Bug: Retrieve user from Redux and include in Order Form #4](https://github.com/Shift3/react-challenge-project-jan-2022/issues/4)
- Includes proposed solution for [Intentional Bug: Order form submit doesn't work #1](https://github.com/Shift3/react-challenge-project-jan-2022/issues/1)

## Pre-Testing TODOs
- Run local environments 
  - Docker backend: `docker compose up`
  - Browser client: `npm start`
- Visit `localhost:3000` in your browser and login (NOTE: any email & password will be accepted)

## Testing Steps
- Select "Order Form" button in the navbar. 
- Select an Item from the "Lunch menu" dropdown, then the "Order It" Button.
- Select "View Order", and scroll to the last item listed. 
- That new order should **include the email you entered when logging in.**
