### PR TITLE
feat(app-router): guard auth routes

### DIFF
--- a/application/src/components/nav/nav.js
+++ b/application/src/components/nav/nav.js
@@ -1,26 +1,46 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { useSelector } from 'react-redux';
+import { logoutUser } from "../../redux/actions/authActions";
 import "./nav.css";
 
 const Nav = (props) => {
+    const auth = useSelector((state) => state.auth);
+
+    const logout = () => {
+      logoutUser();
+    }
+
     return (
-        <div className="nav-strip">
-            <Link to={"/order"} className="nav-link">
-                <div className="nav-link-style">
-                    <label className="nav-label">Order Form</label>
-                </div>
-            </Link>
-            <Link to={"/view-orders"} className="nav-link" id="middle-link">
-                <div className="nav-link-style">
-                    <label className="nav-label">View Orders</label>
-                </div>
-            </Link>
-            <Link to={"/login"} className="nav-link">
-                <div className="nav-link-style">
-                    <label className="nav-label">Log Out</label>
-                </div>
-            </Link>
-        </div>
+      <div>
+          { auth.email &&
+            <div>
+              Authenticated User:
+              <strong> {auth.email} </strong>
+            </div>
+          }
+          <div className="nav-strip">
+              <Link to={"/order"} className="nav-link">
+                  <div className="nav-link-style">
+                      <label className="nav-label">Order Form</label>
+                  </div>
+              </Link>
+              <Link to={"/view-orders"} className="nav-link" id="middle-link">
+                  <div className="nav-link-style">
+                      <label className="nav-label">View Orders</label>
+                  </div>
+              </Link>
+              <Link
+                onClick={() => logout()}
+                to={"/login"}
+                className="nav-link"
+              >
+                  <div className="nav-link-style">
+                      <label className="nav-label">Log Out</label>
+                  </div>
+              </Link>
+          </div>
+      </div>
     );
 }
 

--- a/application/src/router/appRouter.js
+++ b/application/src/router/appRouter.js
@@ -1,14 +1,29 @@
 import React from 'react';
-import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import { Main, Login, OrderForm, ViewOrders} from '../components';
 
 const AppRouter = (props) => {
+
+  const RouteGuarder = ({children}) => {
+    const auth = useSelector((state) => state.auth);
+    if (!auth.token) {
+      return <Redirect to="/login" />
+    } else {
+      return children
+    }
+  }
+
   return (
     <Router>
       <Route path="/" exact component={Main} />
       <Route path="/login" exact component={Login} />
-      <Route path="/order" exact component={OrderForm} />
-      <Route path="/view-orders" exact component={ViewOrders} />
+      <Switch>
+        <RouteGuarder>
+          <Route path="/order" exact component={OrderForm} />
+          <Route path="/view-orders" exact component={ViewOrders} />
+        </RouteGuarder>
+      </Switch>
     </Router>
   );
 }


### PR DESCRIPTION
## Changes
1. `RouteGuarder` sub component is added to `appRouter.js` to check authentication status.
2. `Switch` and `Redirect` are used to handle routing for specified guarded paths.
3. Users that are not authenticated are redirected to the `/login` page. 

## Purpose
The application has specific pages that are open for the public to view. However, some pages require a user to be logged in, so that specific information about that user can be used for actions within that page. 
- This feature allows us to specify what those pages are, and "guard" the ones that require authentication, while escorting our users back to a page that does not require authentication. 

Proposed solution for [Feature Request: Route Guarding #6](https://github.com/Shift3/react-challenge-project-jan-2022/issues/6)
- Includes proposed solution for [Feature Request: Log Out #5](https://github.com/Shift3/react-challenge-project-jan-2022/issues/5)

## Approach
I started this issue out by researching different route guarding methods that people have shared specific to `react-router`
- I generally followed what was outlined from the link in the `## Learning` section below. 
- It did take some tinkering to get it to behave as expected. I do think my understanding of what is going on behind the abstract of the react render is limited to implementation on this issue.

## Pre-Testing TODOs
- Run local environments 
  - Docker backend: `docker compose up`
  - Browser client: `npm start`
- Visit `localhost:3000` in your browser and login (NOTE: any email & password will be accepted)

## Testing Steps
- Select "Log Out" button in the navbar. 
- Try to navigate to `/order` should reroute to `/login`
- Try to navigate to `/order-view` should reroute to `/login`


## Learning
- React Routes: https://blog.netcetera.com/how-to-create-guarded-routes-for-your-react-app-d2fe7c7b6122